### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/benweese/67e641fe-20c6-4660-816f-4802bd7be220/d373441d-8113-49b4-9a3f-de0a46597a69/_apis/work/boardbadge/523a1189-41c8-4c79-82cd-0be6b5810d4b)](https://dev.azure.com/benweese/67e641fe-20c6-4660-816f-4802bd7be220/_boards/board/t/d373441d-8113-49b4-9a3f-de0a46597a69/Microsoft.RequirementCategory)
 # BenWeese.Dev
 - [Home](https://benweese.dev)
 - [Postman](https://benweese.dev/Postman/)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/benweese/67e641fe-20c6-4660-816f-4802bd7be220/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.